### PR TITLE
Typo fixes and README clean ups

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Simplx is open-sourced under the Apache 2.0 license, please see the [accompanyin
 
 ## Getting Started
 
-About a dozen tutorials are included here, please see the [Tutorials README](./tutorials/README.md).
+About a dozen tutorials are included here, please see the [Tutorials README](./tutorial/README.md).
 
 To build the first tutorial, open a terminal at the root of the repository and type:
 

--- a/tutorial/10_timer/README.md
+++ b/tutorial/10_timer/README.md
@@ -1,10 +1,6 @@
 
-# Tutorial #8 - Ping Pong
+# Tutorial #10 - Timer and periodic callbacks
 
-This tutorial shows how Actors are instantiated and how they communicate with each other.
-A PongActor is instantiated as a service on CPU core #2, then a PingActor is instantiated on CPU core #1.
-A TravelLogEvent is sent from Ping to Pong and back to Ping, recording its location at each stop.
-
-The workflow terminates after a hardcoded number for seconds; see tutorial #9 for a better and more elaborate exit procedure.
-
+This tutorial shows how the timer proxy class is used to create periodic callback behaviour. 
+The process will start an actor which outputs a message every second, terminating after three iterations.
 

--- a/tutorial/12_connector/README.md
+++ b/tutorial/12_connector/README.md
@@ -1,0 +1,5 @@
+# Tutorial #12 - TCP and HTTP Connectors
+
+This tutorial consists of two separate examples.
+[TCP Connector](./tcp/sample/README.md) - TCP client and server running on the same core
+[HTTP Connector] - HTTP server demonstration, a fake monitoring service presented as JSON/HTTP.

--- a/tutorial/12_connector/README.md
+++ b/tutorial/12_connector/README.md
@@ -1,5 +1,5 @@
 # Tutorial #12 - TCP and HTTP Connectors
 
 This tutorial consists of two separate examples.
-[TCP Connector](./tcp/sample/README.md) - TCP client and server running on the same core
-[HTTP Connector] - HTTP server demonstration, a fake monitoring service presented as JSON/HTTP.
+1. [TCP Connector](./tcp/sample/README.md) - TCP client and server running on the same host (uses separate processes)
+2. HTTP Connector - HTTP server demonstration, a fake monitoring service presented as JSON/HTTP.

--- a/tutorial/README.md
+++ b/tutorial/README.md
@@ -2,17 +2,18 @@
 
 In this directory you'll find the following tutorials, sorted by inceasing complexity:
 
-1. hello actor
-2. hello world 
-3. printer actor starter
-4. printer actor service
-5. callback
-6. undelivered event management
-7. referenced and unreferenced actors
-8. ping pong
-9. asynchronous exit
-10. timer
-11. asynchronous keyboard polling
-12. asynchronous tcp client & server
+1. [hello actor](./01_hello_actor/README.md) - Introduces the Framework by creating a new Actor
+2. [hello world](./02_hello_world/README.md) - Define your own simple Actor and a Callback
+3. [printer actor starter](./03_printer_actor_starter/README.md) - Create two actors that interact via message passing
+4. [printer actor service](./04_printer_actor_service/README.md) - As example #3 but use the ServiceTag to register in the service index
+5. [multi-callback](./05_multi_callback/README.md) - Use two different callback functions with a single Actor
+6. [undelivered event management](./06_undelivered_event_management/README.md) - why message passing/event delivery may fail and how to handle it.
+7. [referenced and unreferenced actors](./07_referenced_unreferenced_actor/README.md) - Introduces referenced actors and the same core invocation optimisation pattern. 
+8. [ping pong](./08_pingpong/README.md) - Brings together earlier examples to create a two actor system with service discovery and two-way (asynchronous) communication. 
+9. [asynchronous exit](./09_sync_exit/README.md) - Demonstrates a controlled exit using requestDestroy()
+10. [timer](./10_timer/README.md) - Demonstrates a periodic timer using the timer_proxy class.
+11. [asynchronous keyboard polling](./11_keyboard/README.md) - Demonstrates the built-in keyboard actor, handling keypress events
+12. [asynchronous tcp/http client & server](./12_connector/README.md) - Demonstrates TCP and HTTP connector built-in actors
+13. [cross thread bus](./13_cross_thread_bus/README.md) - Demonstrates the integration of cooperative Actor with external services that are not so well-mannered. Can be used for integrating with thirdparty systems with their own eventloops and/or blocking services.
 
 Each folder contains its own README file with further details.

--- a/tutorial/README.md
+++ b/tutorial/README.md
@@ -12,7 +12,7 @@ In this directory you'll find the following tutorials, sorted by inceasing compl
 8. [ping pong](./08_pingpong/README.md) - Brings together earlier examples to create a two actor system with service discovery and two-way (asynchronous) communication. 
 9. [asynchronous exit](./09_sync_exit/README.md) - Demonstrates a controlled exit using requestDestroy()
 10. [timer](./10_timer/README.md) - Demonstrates a periodic timer using the timer_proxy class.
-11. [asynchronous keyboard polling](./11_keyboard/README.md) - Demonstrates the built-in keyboard actor, handling keypress events
+11. [asynchronous keyboard polling](./11_keyboard_actor/README.md) - Demonstrates the built-in keyboard actor, handling keypress events
 12. [asynchronous tcp/http client & server](./12_connector/README.md) - Demonstrates TCP and HTTP connector built-in actors
 13. [cross thread bus](./13_cross_thread_bus/README.md) - Demonstrates the integration of cooperative Actor with external services that are not so well-mannered. Can be used for integrating with thirdparty systems with their own eventloops and/or blocking services.
 


### PR DESCRIPTION
Some quick fix ups for a bad link in the top level README and to add clarity and fix mistakes in the tutorilas README.